### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/View/Base.php
+++ b/lib/Horde/View/Base.php
@@ -11,6 +11,7 @@
  * @category Horde
  * @package View
  */
+#[AllowDynamicProperties]
 abstract class Horde_View_Base
 {
     /**

--- a/lib/Horde/View/Helper/Capture/ContentFor.php
+++ b/lib/Horde/View/Helper/Capture/ContentFor.php
@@ -24,6 +24,7 @@
  * @package    View
  * @subpackage Helper
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_Capture_ContentFor extends Horde_View_Helper_Capture_Base
 {
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/View/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/View/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde View Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/View/BaseTest.php
+++ b/test/Horde/View/BaseTest.php
@@ -26,7 +26,7 @@ class Horde_View_BaseTest extends Horde_Test_Case
 {
     protected $_view = null;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_view = new Horde_View();
         $this->_view->addTemplatePath(__DIR__ . '/fixtures/');
@@ -51,6 +51,7 @@ class Horde_View_BaseTest extends Horde_Test_Case
 
     public function testAssignDoesntOverridePrivateVariables()
     {
+        $this->expectNotToPerformAssertions();
         try {
             $this->_view->assign(array('_templatePath' => 'test'));
         } catch (Exception $e) {
@@ -237,6 +238,8 @@ class Horde_View_BaseTest extends Horde_Test_Case
     // test adding a helper where methods conflict
     public function testAddHorde_View_Helper_TextMethodOverwrite()
     {
+        $this->expectNotToPerformAssertions();
+
         // add text helper
         $this->_view->addHelper(new Horde_View_Helper_Text($this->_view));
 

--- a/test/Horde/View/Helper/BenchmarkTest.php
+++ b/test/Horde/View/Helper/BenchmarkTest.php
@@ -22,9 +22,9 @@
  * @package    View
  * @subpackage UnitTests
  */
-class Horde_View_Helper_BenchmarkTest extends PHPUnit_Framework_TestCase
+class Horde_View_Helper_BenchmarkTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view = new Horde_View();
         $this->view->addHelper(new Horde_View_Helper_Benchmark($this->view));
@@ -35,6 +35,8 @@ class Horde_View_Helper_BenchmarkTest extends PHPUnit_Framework_TestCase
 
     public function testWithoutLogger()
     {
+        $this->expectNotToPerformAssertions();
+
         $this->view = new Horde_View();
         $this->view->addHelper(new Horde_View_Helper_Benchmark($this->view));
 

--- a/test/Horde/View/Helper/BenchmarkTest.php
+++ b/test/Horde/View/Helper/BenchmarkTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_BenchmarkTest extends Horde_Test_Case
 {
     public function setUp(): void
@@ -80,7 +81,7 @@ class Horde_View_Helper_BenchmarkTest extends Horde_Test_Case
     {
         $last = end($this->mock->events);
         $this->assertEquals(strtoupper($level), $last['levelName']);
-        $this->assertRegExp("/^$message \(.*\)$/", $last['message']);
+        $this->assertMatchesRegularExpression("/^$message \(.*\)$/", $last['message']);
     }
 
 }

--- a/test/Horde/View/Helper/CaptureTest.php
+++ b/test/Horde/View/Helper/CaptureTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_CaptureTest extends Horde_Test_Case
 {
     public function setUp(): void
@@ -48,7 +49,7 @@ class Horde_View_Helper_CaptureTest extends Horde_Test_Case
             $this->fail();
         } catch (Exception $e) {
             $this->assertInstanceOf('Horde_View_Exception', $e);
-            $this->assertRegExp('/capture already ended/i', $e->getMessage());
+            $this->assertMatchesRegularExpression('/capture already ended/i', $e->getMessage());
         }
     }
 

--- a/test/Horde/View/Helper/CaptureTest.php
+++ b/test/Horde/View/Helper/CaptureTest.php
@@ -22,9 +22,9 @@
  * @package    View
  * @subpackage UnitTests
  */
-class Horde_View_Helper_CaptureTest extends PHPUnit_Framework_TestCase
+class Horde_View_Helper_CaptureTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view   = new Horde_View();
         $this->helper = new Horde_View_Helper_Capture($this->view);

--- a/test/Horde/View/Helper/DateTest.php
+++ b/test/Horde/View/Helper/DateTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_DateTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/View/Helper/DateTest.php
+++ b/test/Horde/View/Helper/DateTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_DateTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->helper = new Horde_View_Helper_Date(new Horde_View());
     }

--- a/test/Horde/View/Helper/DebugTest.php
+++ b/test/Horde/View/Helper/DebugTest.php
@@ -22,9 +22,9 @@
  * @package    View
  * @subpackage UnitTests
  */
-class Horde_View_Helper_DebugTest extends PHPUnit_Framework_TestCase
+class Horde_View_Helper_DebugTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->helper = new Horde_View_Helper_Debug(new Horde_View());
     }
@@ -37,7 +37,7 @@ class Horde_View_Helper_DebugTest extends PHPUnit_Framework_TestCase
         $expected = '<pre class="debug_dump">string(7) &quot;foo&amp;bar&quot;';
         $output = $this->helper->debug('foo&bar');
         ini_set('xdebug.overload_var_dump', $xdebug);
-        $this->assertContains($expected, $output);
+        $this->assertStringContainsString($expected, $output);
     }
 
 }

--- a/test/Horde/View/Helper/DebugTest.php
+++ b/test/Horde/View/Helper/DebugTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_DebugTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/View/Helper/FormTagTest.php
+++ b/test/Horde/View/Helper/FormTagTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_FormTagTest extends Horde_Test_Functional
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view = new Horde_View();
         $this->view->addHelper('FormTag');

--- a/test/Horde/View/Helper/FormTagTest.php
+++ b/test/Horde/View/Helper/FormTagTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_FormTagTest extends Horde_Test_Functional
 {
     public function setUp(): void

--- a/test/Horde/View/Helper/FormTest.php
+++ b/test/Horde/View/Helper/FormTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_FormTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view = new Horde_View();
         $this->view->addHelper('Form');

--- a/test/Horde/View/Helper/FormTest.php
+++ b/test/Horde/View/Helper/FormTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_FormTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/View/Helper/JavascriptTest.php
+++ b/test/Horde/View/Helper/JavascriptTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_JavascriptTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/View/Helper/JavascriptTest.php
+++ b/test/Horde/View/Helper/JavascriptTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_JavascriptTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view = new Horde_View();
         $this->view->addHelper('Javascript');

--- a/test/Horde/View/Helper/NumberTest.php
+++ b/test/Horde/View/Helper/NumberTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_NumberTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/View/Helper/NumberTest.php
+++ b/test/Horde/View/Helper/NumberTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_NumberTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->helper = new Horde_View_Helper_Number(new Horde_View());
     }

--- a/test/Horde/View/Helper/TagTest.php
+++ b/test/Horde/View/Helper/TagTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_TagTest extends Horde_Test_Case
 {
     public function setUp(): void
@@ -39,7 +40,7 @@ class Horde_View_Helper_TagTest extends Horde_Test_Case
 
     public function testTagOptions()
     {
-        $this->assertRegExp('/\A<p class="(show|elsewhere)" \\/>\z/',
+        $this->assertMatchesRegularExpression('/\A<p class="(show|elsewhere)" \\/>\z/',
                             $this->view->tag('p', array('class' => 'show',
                                                         'class' => 'elsewhere')));
     }

--- a/test/Horde/View/Helper/TagTest.php
+++ b/test/Horde/View/Helper/TagTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_TagTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view = new Horde_View();
         $this->view->addHelper('Tag');

--- a/test/Horde/View/Helper/TextTest.php
+++ b/test/Horde/View/Helper/TextTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_TextTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/View/Helper/TextTest.php
+++ b/test/Horde/View/Helper/TextTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_TextTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->view = new Horde_View();
         $this->view->addHelper('Text');
@@ -102,6 +102,7 @@ class Horde_View_Helper_TextTest extends Horde_Test_Case
 
     public function testCycleClassWithInvalidArguments()
     {
+        $this->expectNotToPerformAssertions();
         try {
             $value = new Horde_View_Helper_Text_Cycle('bad');
             $this->fail();
@@ -155,6 +156,7 @@ class Horde_View_Helper_TextTest extends Horde_Test_Case
 
     public function testResetUnknownCycle()
     {
+        $this->expectNotToPerformAssertions();
         $this->view->resetCycle('colors');
     }
 

--- a/test/Horde/View/Helper/UrlTest.php
+++ b/test/Horde/View/Helper/UrlTest.php
@@ -24,7 +24,7 @@
  */
 class Horde_View_Helper_UrlTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $controller = new Horde_View_Helper_UrlTest_MockController();
         $this->view = new Horde_View();

--- a/test/Horde/View/Helper/UrlTest.php
+++ b/test/Horde/View/Helper/UrlTest.php
@@ -22,6 +22,7 @@
  * @package    View
  * @subpackage UnitTests
  */
+#[AllowDynamicProperties]
 class Horde_View_Helper_UrlTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/View/InterfaceTest.php
+++ b/test/Horde/View/InterfaceTest.php
@@ -15,10 +15,11 @@
  * @package    View
  * @subpackage UnitTests
  */
-class Horde_View_InterfaceTest extends PHPUnit_Framework_TestCase {
+class Horde_View_InterfaceTest extends Horde_Test_Case {
 
     public function testViewInterface()
     {
+        $this->expectNotToPerformAssertions();
         eval('class Test_View extends Horde_View implements Horde_View_Interface {};');
     }
 


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-view/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Fix php8.2 warnings https://salsa.debian.org/horde-team/php-horde-view/-/blob/debian-sid/debian/patches/1020_php8.2.patch
